### PR TITLE
mix reference and value in math operators

### DIFF
--- a/src/systems/polynom.rs
+++ b/src/systems/polynom.rs
@@ -261,7 +261,7 @@ macro_rules! impl_one_operator_scalar_trait {
                     scalar.$operator_fn(rhs)
                 }
             }
-            
+
             impl $operator<$scalar_type> for &$struct_type<$scalar_type>
             {
                 type Output = $struct_type<$scalar_type>;
@@ -1012,8 +1012,7 @@ mod tests {
         let ans: RationalFunction<f64> = 3.0 * rf2;
         assert_abs_diff_eq!(rf1.eval(&1.2), ans.eval(&1.2));
 
-
-        let s = RationalFunction::new_from_coeffs(&[0.0, 1.0], &[1.0]); 
+        let s = RationalFunction::new_from_coeffs(&[0.0, 1.0], &[1.0]);
         let _ = 1.0 / &s * 10.0 * &s - 3.0 / &s;
         let _ = &s * (1.0 + &s);
         let _ = &s + 1.0 - &s / (1.0 + &s) * &s * (1.0 * &s);

--- a/src/systems/state_space.rs
+++ b/src/systems/state_space.rs
@@ -691,10 +691,10 @@ macro_rules! impl_comb_ref_and_no_ref_operators {
                 }
             }
 
-            impl<U: Time + 'static> $operator<Ss<U>> for &Ss<U>  
+            impl<U: Time + 'static> $operator<Ss<U>> for &Ss<U>
             {
                 type Output = Ss<U>;
-                fn $operator_fn(self, rhs: Ss<U>) -> Self::Output { 
+                fn $operator_fn(self, rhs: Ss<U>) -> Self::Output {
                     self.$operator_fn(&rhs)
                 }
             }
@@ -702,9 +702,12 @@ macro_rules! impl_comb_ref_and_no_ref_operators {
     };
 }
 
-impl_comb_ref_and_no_ref_operators!(
-    [(Add, add), (Sub, sub), (Mul, mul), (Div, div)]
-);
+impl_comb_ref_and_no_ref_operators!([
+    (Add, add),
+    (Sub, sub),
+    (Mul, mul),
+    (Div, div)
+]);
 
 impl<U: Time + 'static> fmt::Display for Ss<U> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1024,7 +1027,6 @@ mod tests {
 
         assert_abs_diff_eq!(resp1.re, resp2.re, epsilon = 1e-9);
         assert_abs_diff_eq!(resp1.im, resp2.im, epsilon = 1e-9);
-
 
         let s_inv = (1.0 / Tf::s()).to_ss().unwrap();
         let _ = 1.0 + &s_inv * &s_inv / (1.0 + &s_inv / 1.0);

--- a/src/systems/state_space.rs
+++ b/src/systems/state_space.rs
@@ -658,11 +658,53 @@ macro_rules! impl_scalar_math_operator_ss {
                     lhs_ss.$operator_fn(rhs)
                 }
             }
+
+            impl<U: Time + 'static> $operator<f64> for &Ss<U> {
+                type Output = Ss<U>;
+                fn $operator_fn(self, rhs: f64) -> Self::Output {
+                    let rhs_ss = Ss::<U>::new_from_scalar(rhs);
+                    self.$operator_fn(&rhs_ss)
+                }
+            }
+
+            impl<U: Time + 'static> $operator<&Ss<U>> for f64 {
+                type Output = Ss<U>;
+                fn $operator_fn(self, rhs: &Ss<U>) -> Self::Output {
+                    let scalar_ss = Ss::<U>::new_from_scalar(self);
+                    (&scalar_ss).$operator_fn(rhs)
+                }
+            }
         )*
     };
 }
 
 impl_scalar_math_operator_ss!([(Add, add), (Sub, sub), (Mul, mul), (Div, div)]);
+
+macro_rules! impl_comb_ref_and_no_ref_operators {
+    ([$(($operator:ident, $operator_fn:ident)), *]) => {
+        $(
+            impl<U: Time + 'static> $operator<&Ss<U>> for Ss<U>
+            {
+                type Output = Ss<U>;
+                fn $operator_fn(self, rhs: &Ss<U>) -> Self::Output {
+                    (&self).$operator_fn(rhs)
+                }
+            }
+
+            impl<U: Time + 'static> $operator<Ss<U>> for &Ss<U>  
+            {
+                type Output = Ss<U>;
+                fn $operator_fn(self, rhs: Ss<U>) -> Self::Output { 
+                    self.$operator_fn(&rhs)
+                }
+            }
+        )*
+    };
+}
+
+impl_comb_ref_and_no_ref_operators!(
+    [(Add, add), (Sub, sub), (Mul, mul), (Div, div)]
+);
 
 impl<U: Time + 'static> fmt::Display for Ss<U> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -982,5 +1024,9 @@ mod tests {
 
         assert_abs_diff_eq!(resp1.re, resp2.re, epsilon = 1e-9);
         assert_abs_diff_eq!(resp1.im, resp2.im, epsilon = 1e-9);
+
+
+        let s_inv = (1.0 / Tf::s()).to_ss().unwrap();
+        let _ = 1.0 + &s_inv * &s_inv / (1.0 + &s_inv / 1.0);
     }
 }

--- a/src/systems/state_space.rs
+++ b/src/systems/state_space.rs
@@ -1029,6 +1029,10 @@ mod tests {
         assert_abs_diff_eq!(resp1.im, resp2.im, epsilon = 1e-9);
 
         let s_inv = (1.0 / Tf::s()).to_ss().unwrap();
-        let _ = 1.0 + &s_inv * &s_inv / (1.0 + &s_inv / 1.0);
+        let _ = 1.0 + &s_inv * &s_inv / (1.0 + &s_inv / 1.0) + (&s_inv - &s_inv);
+        let _ = 1.0 + &s_inv;
+        let _ = s_inv.clone() + &s_inv;
+        let _ = &s_inv + s_inv.clone();
+
     }
 }

--- a/src/systems/state_space.rs
+++ b/src/systems/state_space.rs
@@ -1029,10 +1029,10 @@ mod tests {
         assert_abs_diff_eq!(resp1.im, resp2.im, epsilon = 1e-9);
 
         let s_inv = (1.0 / Tf::s()).to_ss().unwrap();
-        let _ = 1.0 + &s_inv * &s_inv / (1.0 + &s_inv / 1.0) + (&s_inv - &s_inv);
+        let _ =
+            1.0 + &s_inv * &s_inv / (1.0 + &s_inv / 1.0) + (&s_inv - &s_inv);
         let _ = 1.0 + &s_inv;
         let _ = s_inv.clone() + &s_inv;
         let _ = &s_inv + s_inv.clone();
-
     }
 }

--- a/src/systems/transfer_function.rs
+++ b/src/systems/transfer_function.rs
@@ -402,12 +402,12 @@ macro_rules! impl_comb_ref_and_no_ref_operators {
                 }
             }
 
-            impl<T, U: Time> $operator<$struct_type<T, U>> for &$struct_type<T, U>  
+            impl<T, U: Time> $operator<$struct_type<T, U>> for &$struct_type<T, U>
             where
                 T: $operator<Output = T> + Clone + Zero + One+ Default + Add + AddAssign + Mul<Output = T> + Neg<Output = T> + Copy,
             {
                 type Output = $struct_type<T, U>;
-                fn $operator_fn(self, rhs: $struct_type<T, U>) -> Self::Output { 
+                fn $operator_fn(self, rhs: $struct_type<T, U>) -> Self::Output {
                     self.$operator_fn(&rhs)
                 }
             }


### PR DESCRIPTION
- allow mixing of reference and value in math operators. Such as:

```rust
let s = Tf::s();
let sys = 1.0 / &s * (10.0 / (&s + 10.0);
```